### PR TITLE
updates: add update to next stable option

### DIFF
--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -104,6 +104,10 @@ msgctxt "#715"
 msgid "Set to ON and an on-screen notification will be displayed when a new update is available"
 msgstr ""
 
+msgctxt "#716"
+msgid "Update to the next stable release instead of remaining on nightly builds, when the next stable release is ready."
+msgstr ""
+
 msgctxt "#718"
 msgid "Send boot config files from /flash, kodi.log, kernel log and Samba configs to http://ix.io, and display the short URL"
 msgstr ""
@@ -454,6 +458,10 @@ msgstr ""
 
 msgctxt "#32029"
 msgid "up to date: %s"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Update To Next Stable"
 msgstr ""
 
 msgctxt "#32100"

--- a/src/oe.py
+++ b/src/oe.py
@@ -909,7 +909,7 @@ def parse_os_release():
 
 
 def get_os_release():
-    distribution = version = architecture = build = project = device = builder_name = builder_version = ''
+    distribution = version = architecture = build = project = device = builder_name = builder_version = last_stable = ''
     os_release_info = parse_os_release()
     if os_release_info is not None:
         if 'NAME' in os_release_info:
@@ -930,6 +930,8 @@ def get_os_release():
             builder_name = os_release_info['BUILDER_NAME']
         if 'BUILDER_VERSION' in os_release_info:
             builder_version = os_release_info['BUILDER_VERSION']
+        if 'LAST_STABLE' in os_release_info:
+            last_stable = os_release_info['LAST_STABLE']
         return (
             distribution,
             version,
@@ -938,7 +940,8 @@ def get_os_release():
             project,
             device,
             builder_name,
-            builder_version
+            builder_version,
+            last_stable
             )
 
 def hash_password(password):
@@ -974,6 +977,7 @@ PROJECT = os_release_data[4]
 DEVICE = os_release_data[5]
 BUILDER_NAME = os_release_data[6]
 BUILDER_VERSION = os_release_data[7]
+LAST_STABLE = os_release_data[8]
 DOWNLOAD_DIR = '/storage/downloads'
 XBMC_USER_HOME = os.environ.get('XBMC_USER_HOME', '/storage/.kodi')
 CONFIG_CACHE = os.environ.get('CONFIG_CACHE', '/storage/.cache')


### PR DESCRIPTION
This is to remove some of the issues around auto updating to stable from the
nightly builds. It also give the user more control over auto updates since
the user can now specify a preference whether or not to auto return to stable
builds when the next stable build is available.